### PR TITLE
do not unlabel UNKNOWN mergeable state

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -122,7 +122,7 @@ export async function run() {
   let pullrequestsWithConflictResolution: IGithubPRNode[];
   pullrequestsWithConflictResolution = pullRequests.filter(
     (pullrequest: IGithubPRNode) => {
-      return pullrequest.node.mergeable !== 'CONFLICTING';
+      return pullrequest.node.mergeable === 'MERGEABLE';
     }
   );
 


### PR DESCRIPTION
If the mergeable state is UNKNOWN (one of the not CONFLICTING states),
it is not safe to unlabel.

fixes #38