### PR TITLE
Refresh dist and update version to use a semantic version

### DIFF
--- a/dist/lib/main.js
+++ b/dist/lib/main.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.run = void 0;
 const core = require("@actions/core");
 const github = require("@actions/github");
 const queries_1 = require("./queries");

--- a/dist/lib/queries.js
+++ b/dist/lib/queries.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.removeLabelsFromLabelable = exports.addLabelsToLabelable = exports.getLabels = exports.getPullRequests = void 0;
 const core = require("@actions/core");
 const getPullRequestPages = (octokit, context, cursor) => {
     let query;

--- a/dist/lib/util.js
+++ b/dist/lib/util.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.getPullrequestsWithoutMergeStatus = exports.wait = void 0;
 async function wait(ms) {
     return new Promise((resolve) => {
         setTimeout(resolve, ms);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Github Action to automatically label PRs with 'conflict' label",
   "private": true,
   "author": "Marko Schilde",
-  "version": "2.2",
+  "version": "2.2.0",
   "scripts": {
     "build": "yarn lint && rm -rf dist && tsc -p ./tsconfig.json",
     "lint": "tslint -p ./tsconfig.json *.ts",


### PR DESCRIPTION
Make sure dist files are up to date by running `npm run-script build`

Note: we probably do not care but `dist/jest.config.js` and `dist/__tests__/` are regenerated 