### PR TITLE
Add option for MAX_RETRIES and WAIT_MS

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,18 @@ jobs:
         with:
           CONFLICT_LABEL_NAME: "has conflicts"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAX_RETRIES: 5
+          WAIT_MS: 5000
 ```
 
 The label from step 1 should be referenced in the parameter `CONFLICT_LABEL_NAME`
 
 Take a look at [this repo](https://github.com/mschilde/auto-label-merge-conflicts/blob/master/%2Egithub/workflows/label_merge_conflicts.yml) for an example setup.
+
+### Arguments:
+
+* MAX_RETRIES: optional (default 5)
+* WAIT_MS: optional (default 5000)
 
 ## Limitations
 
@@ -49,6 +56,7 @@ Github does not reliably compute the `mergeable` status which is used by this ac
 If `master` changes the mergeable status is unknown until someone (most likely this action) requests it. [Github then tries to compute the status with an async job.](https://stackoverflow.com/a/30620973) 
 
 This is usually quick and simple, but there are no guarantees and Github might have issues.
+You can tweak `MAX_RETRIES` and `WAIT_MS` to increase the timeout before giving up on a Pull Request.
 
 ## Local dev setup
 

--- a/action.yml
+++ b/action.yml
@@ -11,9 +11,19 @@ inputs:
   GITHUB_TOKEN:
     description: 'Github token / secret'
     required: true
+  MAX_RETRIES:
+    description: 'number of times to retry on a failed mergable check'
+    required: false
+    default: 5
+  WAIT_MS:
+    description: 'miliseconds between retries'
+    required: false
+    default: 5000
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     - ${{ inputs.CONFLICT_LABEL_NAME }}
     - ${{ inputs.GITHUB_TOKEN }}
+    - ${{ inputs.MAX_RETRIES }}
+    - ${{ inputs.WAIT_MS }}

--- a/dist/lib/main.js
+++ b/dist/lib/main.js
@@ -12,8 +12,9 @@ async function run() {
         required: true
     });
     const octokit = new github.GitHub(myToken);
-    const maxRetries = 5;
-    const waitMs = 5000;
+    const maxRetries = Number(core.getInput('MAX_RETRIES'));
+    const waitMs = Number(core.getInput('WAIT_MS'));
+    console.debug(`maxRetries=${maxRetries} ; waitMs=${waitMs}`);
     // fetch label data
     let labelData;
     try {

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -18,8 +18,9 @@ export async function run() {
   });
 
   const octokit = new github.GitHub(myToken);
-  const maxRetries = 5;
-  const waitMs = 5000;
+  const maxRetries = Number( core.getInput('MAX_RETRIES') );
+  const waitMs = Number( core.getInput('WAIT_MS') );
+  console.debug(`maxRetries=${maxRetries} ; waitMs=${waitMs}`);
 
   // fetch label data
   let labelData;


### PR DESCRIPTION
You can now tweak these two variables to increase
the max timeout if needed.

Default values stay the same.

(cherry picked from commit 50001a0f01379f81028507730aff322967bbfb04)
Signed-off-by: Nicolas R <nicolas@atoomic.org>