### PR TITLE
Consider merge conflict only in dirty status

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    types:
+      - synchronize
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/dist/lib/main.js
+++ b/dist/lib/main.js
@@ -62,7 +62,7 @@ async function run() {
     }
     let pullrequestsWithConflicts;
     pullrequestsWithConflicts = pullRequests.filter((pullrequest) => {
-        return pullrequest.node.mergeable === 'CONFLICTING';
+        return pullrequest.node.mergeable === 'DIRTY';
     });
     // label PRs with conflicts
     if (pullrequestsWithConflicts.length > 0) {
@@ -94,7 +94,7 @@ async function run() {
     }
     let pullrequestsWithConflictResolution;
     pullrequestsWithConflictResolution = pullRequests.filter((pullrequest) => {
-        return pullrequest.node.mergeable === 'MERGEABLE';
+        return pullrequest.node.mergeable !== 'DIRTY';
     });
     // unlabel PRs without conflicts
     if (pullrequestsWithConflictResolution.length > 0) {

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -85,7 +85,7 @@ export async function run() {
   let pullrequestsWithConflicts: IGithubPRNode[];
   pullrequestsWithConflicts = pullRequests.filter(
     (pullrequest: IGithubPRNode) => {
-      return pullrequest.node.mergeable === 'CONFLICTING';
+      return pullrequest.node.mergeable === 'DIRTY';
     }
   );
 
@@ -123,7 +123,7 @@ export async function run() {
   let pullrequestsWithConflictResolution: IGithubPRNode[];
   pullrequestsWithConflictResolution = pullRequests.filter(
     (pullrequest: IGithubPRNode) => {
-      return pullrequest.node.mergeable === 'MERGEABLE';
+      return pullrequest.node.mergeable !== 'DIRTY';
     }
   );
 

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -13,7 +13,7 @@ const getPullRequestPages = (octokit: github.GitHub, context: Context, cursor?: 
             node {
               id
               number
-              mergeable
+              mergeStateStatus
               labels(first: 100) {
                 edges {
                   node {
@@ -40,7 +40,7 @@ const getPullRequestPages = (octokit: github.GitHub, context: Context, cursor?: 
             node {
               id
               number
-              mergeable
+              mergeStateStatus
               labels(first: 100) {
                 edges {
                   node {
@@ -62,7 +62,7 @@ const getPullRequestPages = (octokit: github.GitHub, context: Context, cursor?: 
   }
 
   return octokit.graphql(query, {
-    headers: { Accept: 'application/vnd.github.ocelot-preview+json' }
+    headers: { Accept: 'application/vnd.github.merge-info-preview+json' }
   });
 };
 


### PR DESCRIPTION
Right now, the label is not removed in other states (like checks not passing, reviewers required...)

With this, the action now considers only if the PR is dirty or not according to [MergeStateStatus](https://docs.github.com/en/graphql/reference/enums#mergestatestatus). We're using the mergeStateStatus preview as [noted in GH docs](https://docs.github.com/en/graphql/reference/objects#pullrequest) [(schema info here)](https://docs.github.com/en/graphql/overview/schema-previews#merge-info-preview)

I also modified the README as the example workflow didn't take in account cases where a PR's tracking branch is rebased, for instance.