### PR TITLE
fix: pin Dockerfile to node:22-alpine to restore yarn availability

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,13 +1,8 @@
 dependencies:
-  - changed-files:
-      - any-glob-to-any-file:
-          - yarn.lock
-          - package.json
+  - yarn.lock
+  - package.json
 github:
-  - changed-files:
-      - any-glob-to-any-file:
-          - .github/**
+  - .github/*
+  - .github/**/*
 lint:
-  - changed-files:
-      - any-glob-to-any-file:
-          - .tslint.json
+  - .tslint.json

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,8 +1,13 @@
 dependencies:
-  - yarn.lock
-  - package.json
+  - changed-files:
+      - any-glob-to-any-file:
+          - yarn.lock
+          - package.json
 github:
-  - .github/*
-  - .github/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/**
 lint:
-  - .tslint.json
+  - changed-files:
+      - any-glob-to-any-file:
+          - .tslint.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,11 @@ jobs:
     name: Test & Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          path: ''
-      - run: |
-          git fetch --prune --unshallow
+      - uses: actions/checkout@v6
       - name: checkout
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
-          node-version: 12
+          node-version: 20
       - name: install
         run: yarn install
       - name: lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,18 @@ jobs:
         run: yarn test
       - name: fix COV paths
         run: cp test-report.xml test-report2.xml && sed 's/\/home\/runner\/work\/auto-label-merge-conflicts\/auto-label-merge-conflicts/\/github\/workspace/g' test-report2.xml > test-report.xml
+
+  docker:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       - name: checkout
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
       - name: install
         run: yarn install
       - name: lint

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,7 +1,10 @@
 name: 'Auto Label'
-on: [pull_request]
+on: [pull_request_target]
 jobs:
   label:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v2

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -4,6 +4,6 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v6
+    - uses: actions/labeler@v2
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -4,6 +4,6 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v2
+    - uses: actions/labeler@v6
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:alpine
+FROM node:22-alpine
 
 WORKDIR /home/autolabel
 
 COPY package.json yarn.lock ./
-RUN corepack enable && yarn install --frozen-lockfile
+RUN npm install -g yarn && yarn install --frozen-lockfile
 COPY . .
 
 ENTRYPOINT ["node", "/home/autolabel/dist/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:22-alpine
 WORKDIR /home/autolabel
 
 COPY package.json yarn.lock ./
-RUN npm install -g yarn && yarn install --frozen-lockfile
+RUN yarn install --frozen-lockfile
 COPY . .
 
 ENTRYPOINT ["node", "/home/autolabel/dist/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:alpine
 WORKDIR /home/autolabel
 
 COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile
+RUN corepack enable && yarn install --frozen-lockfile
 COPY . .
 
 ENTRYPOINT ["node", "/home/autolabel/dist/index.js"]


### PR DESCRIPTION
## What does this PR do?

Fixes the broken Docker build caused by `yarn` no longer being available in `node:alpine` images since Node.js 16.10. Also bumps stale CI actions and fixes the labeler workflow so it can write labels on fork PRs.

## Changes

- **Dockerfile**: pin to `node:22-alpine` (LTS) — yarn is still bundled in this image, resolving the `yarn: not found` error with no other changes needed
- **`ci.yml`**: bump actions to v6, Node.js 12 → 22, add a Docker build job with BuildKit caching so this class of failure is caught in CI going forward
- **`label.yml`**: switch to `pull_request_target` with explicit permissions so the labeler can write labels on fork PRs

## Verification

Tested locally with `docker build` and in CI: https://github.com/bhimrazy/auto-label-merge-conflicts/pull/1

Example of the downstream failure this fixes: https://github.com/Lightning-AI/pytorch-lightning/actions/runs/25529252814/job/74931695561